### PR TITLE
Support #[kv(collection, flatten([prefix = "..."])]

### DIFF
--- a/kv-derive-impl/src/producer.rs
+++ b/kv-derive-impl/src/producer.rs
@@ -87,6 +87,7 @@ impl<V, P: Producer<V> + Copy + Clone> Producer<Vec<V>> for CollectionProducer<P
 /// Simple flattening producer.
 ///
 /// Forwards all the key-value pairs from the inner structure.
+#[derive(Copy, Clone)]
 pub struct FlatteningProducer;
 
 impl<T: IntoVec> Producer<T> for FlatteningProducer {
@@ -102,6 +103,7 @@ impl<T: IntoVec> Producer<T> for FlatteningProducer {
 ///
 /// Forwards all the key-value pairs from the inner structure,
 /// but additionally prepends the keys with the prefix.
+#[derive(Copy, Clone)]
 pub struct PrefixedFlatteningProducer(pub &'static str);
 
 impl<V: IntoVec> Producer<V> for PrefixedFlatteningProducer {


### PR DESCRIPTION
Currently when trying to do something similar to:

```rust
use kv_derive::{prelude::*, IntoVec};

#[derive(IntoVec)]
pub struct Complex {
    x: String,
}

#[derive(IntoVec)]
pub struct Test {
    #[kv(flatten(prefix = "xs::"), collection)]
    xs: Vec<Complex>,
}
```

the code generation creates non-compiling code due to the requirement of [CollectionProducer\<P\>](https://docs.rs/kv-derive/1.0.0/kv_derive/producer/struct.CollectionProducer.html#) to have `P` be `Copy` and `Clone`, but [FlatteningProducer](https://docs.rs/kv-derive/1.0.0/kv_derive/producer/struct.FlatteningProducer.html) and [PrefixedFlatteningProducer](https://docs.rs/kv-derive/1.0.0/kv_derive/producer/struct.PrefixedFlatteningProducer.html) do not derive `Copy` and `Clone`. As these clones are trivial, this MR adds them.